### PR TITLE
HER- 42 replace use navigate with link

### DIFF
--- a/frontend/src/components/auth/Logout.jsx
+++ b/frontend/src/components/auth/Logout.jsx
@@ -48,6 +48,7 @@ export default function Logout({ setLoggedIn, setUser }) {
         localStorage.removeItem('jwt');
         setLoggedIn(false);
         setUser(null);
+        navigate("/");
         
         console.log("Logout successful.")
 

--- a/frontend/src/components/pages/Contact.jsx
+++ b/frontend/src/components/pages/Contact.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { Navigate, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { API_URL } from '../../constants';
 
 

--- a/frontend/src/components/pages/Contact.jsx
+++ b/frontend/src/components/pages/Contact.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router-dom';
 import { API_URL } from '../../constants';
 
 
@@ -10,6 +10,7 @@ function Contact({ user }) {
     const [message, setMessage] = useState("");
     const [errorMessages, setErrorMessages] = useState("");
     const contactUrl = `${API_URL}/contacts`
+    const navigate = useNavigate();
 
     useEffect(() => {
         window.scrollTo(0, 0);
@@ -46,15 +47,9 @@ function Contact({ user }) {
                 const errorData = await response.json();
                 setErrorMessages(errorData.errors.join(", "));
             } else {
-                // Handle success, clear the form
-                // Added code to clear first and last name
-                console.log(response.json)
-                setName("");
-                setEmail("");
-                setPhone("");
-                setMessage("");
-                setErrorMessages("");
                 alert("Contact submitted successfully!");
+                navigate("/");
+
             }
         } catch (error) {
             setErrorMessages("An error occurred. Please try again.");

--- a/frontend/src/components/pages/Contact.jsx
+++ b/frontend/src/components/pages/Contact.jsx
@@ -49,7 +49,6 @@ function Contact({ user }) {
             } else {
                 alert("Contact submitted successfully!");
                 navigate("/");
-
             }
         } catch (error) {
             setErrorMessages("An error occurred. Please try again.");

--- a/frontend/src/components/pages/Kits.jsx
+++ b/frontend/src/components/pages/Kits.jsx
@@ -37,20 +37,6 @@ function Kits({user, setUser}) {
     loadKits();
   }, [kitsUrl]);
 
-  // Stretch Goal: Send user back to the resource they requested after login
-  const handleOrderKit = (kitId) => {
-    if (!user) {
-      // Alert the user that they must log in first
-      alert('You must log in to request a kit.');
-  
-      navigate('/login');
-    } else {
-      // If the user exists, navigate to the RequestKit page and pass kitId as state to ensure they request the correct kit selection
-      navigate('/orders', { state: { kitId } });
-    }
-  };
-  
-
   return (
     // Displays kit page
     <>
@@ -112,9 +98,12 @@ function Kits({user, setUser}) {
                             {kit.description}
                           </div>
                           
-                            <button className="btn btn-primary btn-small" onClick= {() => handleOrderKit(kit.id)}>
-                              Order {kit.name}
-                            </button>
+                          <Link 
+                            to="/orders" state= { kit.id }
+                            className="btn btn-primary btn-small"
+                          >
+                            Order {kit.name}
+                          </Link>
                           
                         </div>
                         <div>

--- a/frontend/src/components/pages/Kits.jsx
+++ b/frontend/src/components/pages/Kits.jsx
@@ -1,15 +1,12 @@
 import React, { useState, useEffect } from "react";
 import { API_URL } from "../../constants";
 import { Link } from "react-router-dom";
-import { useNavigate } from "react-router-dom";
-import RequestKit from "./RequestKit";
 
 function Kits({user, setUser}) {
   const [kits, setKits] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const kitsUrl = `${API_URL}/kits`;
-  const navigate = useNavigate();
 
   useEffect(() => {
     window.scrollTo(0, 0);

--- a/frontend/src/components/pages/Kits.jsx
+++ b/frontend/src/components/pages/Kits.jsx
@@ -97,12 +97,17 @@ function Kits({user}) {
                             {kit.description}
                           </div>
                           
-                          <Link 
-                            to="/orders" state= { kit.id, kit.name }
-                            className="btn btn-primary btn-small"
-                          >
-                            Order {kit.name}
-                          </Link>
+                          {user ? (
+                            <Link 
+                              to="/orders" 
+                              state={{ kitId: kit.id, kitName: kit.name }}
+                              className="btn btn-primary btn-small"
+                            >
+                              Order {kit.name}
+                            </Link>
+                          ) : (
+                            <p><em>Please log in to place an order.</em></p>
+                          )}
 
                           
                         </div>

--- a/frontend/src/components/pages/RequestKit.jsx
+++ b/frontend/src/components/pages/RequestKit.jsx
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom";
 
 function RequestKit({ user }) {
   const location = useLocation();
-  const kitId = location.state?.kitId || "";
+  const kitId = location.state || "";
 
   const [orderMessages, setOrderMessages] = useState("");
 

--- a/frontend/src/components/pages/RequestKit.jsx
+++ b/frontend/src/components/pages/RequestKit.jsx
@@ -41,13 +41,6 @@ function RequestKit({ user }) {
         comments: orderForm.comments,
       },
     };
-    
-    if (!jwt) {
-      console.log("No user logged in. Please log in to continue.");
-      // Redirect to login
-      navigate("/login");
-      return;
-    }
 
 
     try {


### PR DESCRIPTION
<!-- PR Title format: "<JIRA_TICKET_ID>: <TICKET_TITLE>"-->
HER-42: Replace useNavigate with Link [FE]
## Issue

https://raquelanaroman.atlassian.net/browse/HER-42

<!-- Copy the JIRA Ticket Description! ⬇️ -->
Description

The FE ui current makes heavy use of the React Router useNavigate hook.

Per the [documentation](https://reactrouter.com/start/library/navigating#usenavigate):

For normal navigation, it's best to use Link or NavLink. They provide a better default user experience like keyboard events, accessibility labeling, "open in new window", right click context menus, etc.

Reserve usage of useNavigate to situations where the user is not interacting but you need to navigate, for example:

After a form submission completes

Logging them out after inactivity

Timed UIs like quizzes, etc.

 

This is particularly undesirable because it does not easily pass state between pages, but Link allows us to via the [LinkProps.state attribute it accepts as a second arg.](https://github.com/remix-run/react-router/blob/74737750ca0abab137859d445e1a66eb59a56ba2/packages/react-router/lib/dom/lib.tsx#L558-L573)
<!-- Link any related PRs to this PR -->

## Changes

* Use Link instead of useNavigate() in Kits component

<!-- Describe your changes in detail. -->

### Review Checklist

- [x] I have documented my code with code comments.
