### PR TITLE
HER-65: FIX_SEED_DATA_FOR_ADDRESS_USER_AND_ORDER_MODELS

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,11 +10,14 @@
 #   end
 # Initial seeding of my database
 require 'faker'
+require 'factory_bot_rails'
 
 # Clear tables
 Order.destroy_all
 KitItem.destroy_all
 Kit.destroy_all
+Address.destroy_all
+User.destroy_all
 
 
 
@@ -291,29 +294,17 @@ empowerment_kit.kit_items << boy_bat_book << temple_book << see_me_book << vivy_
 perspectives_kit.kit_items << goldfish_boy_book << sevens_book << frankie_book << earth_blue_book << same_book << awesome_guide_book << mockingbird_book << classroom_book << neurotribes_book
 impact_kit.kit_items << curious_dog_book << rosie_book << different_book << classroom_book << neurotribes_book
 
-# Seeding user
-user = User.find_or_create_by!(email: "test@example3.com") do |u|
-  u.first_name = "Test"
-  u.last_name = "User"
-  u.password = "password123"
-  u.role = "teacher"
+# Seed users
+3.times do
+  FactoryBot.create(:user)
 end
 
-# Seeding Address
-address = Address.create!(
-  street_address: Faker::Address.street_address,
-  city: Faker::Address.city,
-  state: Faker::Address.state_abbr,
-  postal_code: Faker::Address.zip_code,
-  addressable: user
-)
+# Seed addresses
+10.times do
+  FactoryBot.create(:address)
+end
 
-# Seeding Order
-order = Order.create!(
-  school_year: '2024-2025',
-  kit: discovery_kit,
-  phone: "#{Faker::Number.number(digits: 3)}-#{Faker::Number.number(digits: 3)}-#{Faker::Number.number(digits: 4)}",
-  comments: 'This is wonderful',
-  user: user,
-  address: address
-)
+# Seed orders
+3.times do
+  FactoryBot.create(:order)
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
       role { "admin" }
     end
 
-    trait :speaker do
+    trait :speaker_user do
       role { "speaker" }
     end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -18,10 +18,5 @@ FactoryBot.define do
     trait :regular_user do
       role { "user" }
     end
-
-    # To include address-user associations
-    after(:build) do |user|
-      user.addresses << build(:address, addressable: user)
-    end
   end
 end


### PR DESCRIPTION
<!-- PR Title format: "<JIRA_TICKET_ID>: <TICKET_TITLE>"-->

## Issue HER-65: Fix seed data for address, user, and order models

https://raquelanaroman.atlassian.net/browse/HER-65

<!-- Copy the JIRA Ticket Description! ⬇️ -->
**Description**
During the last database reset and seeding it turned out that seeding is not working. 
db:seed command gave an error of “Busy extension” on the line where User seeding starts.

**Task**
In seeds.rb ensure user, address, and order seeding are done using user, address, and order factories

**Acceptance Criteria**
Ensure seeding is working

<!-- Link any related PRs to this PR -->

## Changes

<!-- Describe your changes in detail. -->

1. Added commands to seeds.db to clear data from database tables
2. Added require 'factory_bot_rails' to seeds.rb to use existing factories for seeding users, addresses, and orders.

### Review Checklist

- [x] I have documented my code with code comments.

<img width="1440" alt="Screenshot 2025-01-04 at 8 40 06 PM" src="https://github.com/user-attachments/assets/ea0aa6bd-b208-4b87-bb6d-dc5368e8714e" />

