### PR TITLE
HER-22 Migration: Drop address related columns from Order table

### DIFF
--- a/db/migrate/20250106013942_remove_school_name_and_school_address_from_orders_again.rb
+++ b/db/migrate/20250106013942_remove_school_name_and_school_address_from_orders_again.rb
@@ -1,0 +1,7 @@
+class RemoveSchoolNameAndSchoolAddressFromOrdersAgain < ActiveRecord::Migration[7.2]
+  def change
+    change_table :orders do |t|
+      t.remove :school_name, :school_address
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_03_100137) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_06_013942) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -39,17 +39,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_03_100137) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "availabilities", force: :cascade do |t|
-    t.datetime "start_time", null: false
-    t.datetime "end_time", null: false
-    t.integer "speaker_id", null: false
-    t.integer "recurring_availability_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["recurring_availability_id"], name: "index_availabilities_on_recurring_availability_id"
-    t.index ["speaker_id"], name: "index_availabilities_on_speaker_id"
-  end
-    
   create_table "addresses", force: :cascade do |t|
     t.string "street_address", null: false
     t.string "city", null: false
@@ -60,6 +49,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_03_100137) do
     t.string "addressable_type", null: false
     t.integer "addressable_id", null: false
     t.index ["addressable_type", "addressable_id"], name: "index_addresses_on_addressable"
+  end
+
+  create_table "availabilities", force: :cascade do |t|
+    t.datetime "start_time", null: false
+    t.datetime "end_time", null: false
+    t.integer "speaker_id", null: false
+    t.integer "recurring_availability_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recurring_availability_id"], name: "index_availabilities_on_recurring_availability_id"
+    t.index ["speaker_id"], name: "index_availabilities_on_speaker_id"
   end
 
   create_table "contacts", force: :cascade do |t|
@@ -121,8 +121,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_03_100137) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "phone"
-    t.string "school_name"
-    t.string "school_address"
     t.text "comments"
     t.integer "user_id"
     t.integer "address_id"
@@ -159,8 +157,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_03_100137) do
   add_foreign_key "availabilities", "users", column: "speaker_id"
   add_foreign_key "contacts", "users"
   add_foreign_key "donations", "users"
-  add_foreign_key "orders", "addresses"
   add_foreign_key "events", "users", column: "speaker_id"
+  add_foreign_key "orders", "addresses"
   add_foreign_key "orders", "kits"
   add_foreign_key "orders", "users"
 end


### PR DESCRIPTION
<!-- PR Title format: "<JIRA_TICKET_ID>: <TICKET_TITLE>"-->

## Issue 
HER-22 Migration: Drop address related columns from Order table

https://raquelanaroman.atlassian.net/browse/HER-22

<!-- Copy the JIRA Ticket Description! ⬇️ -->
**Description**

Create a migration for the orders table that:
- removes school_name
- removes school_address

You can use change_table and t.remove to do this elegantly ([docs](https://apidock.com/rails/ActiveRecord/ConnectionAdapters/SchemaStatements/change_table)):

```
change_table(:table_name) do |t|
  t.remove :column_name, :column_name, ...
end
```
<!-- Link any related PRs to this PR -->

## Changes

<!-- Describe your changes in detail. -->
1. Generated migration to remove school_name and school_address from orders table.
2. Update migration file to remove school_name and school_address from orders table.
3. Run migration.

### Review Checklist

- [x] I have documented my code with code comments.
