### PR TITLE
HER-59-notify-speaker-of-booking-modification

### DIFF
--- a/app/controllers/api/v1/bookings_controller.rb
+++ b/app/controllers/api/v1/bookings_controller.rb
@@ -27,10 +27,15 @@ class Api::V1::BookingsController < ApplicationController
     booking = Booking.find(params[:id])
     availability = booking.availability
 
-    if @booking.update(booking_params)
-      render json: @booking
+    if @booking.status == 'pending'
+      if @booking.update(booking_params)
+        BookingMailer.booking_modified_notification(@booking.speaker, @booking).deliver_now
+        render json: @booking
+      else
+        render json: @booking.errors, status: :unprocessable_entity
+      end
     else
-      render json: @booking.errors, status: :unprocessable_entity
+      render json: { error: 'Booking cannot be modified once it is accepted or declined.'}, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/v1/bookings_controller.rb
+++ b/app/controllers/api/v1/bookings_controller.rb
@@ -27,7 +27,7 @@ class Api::V1::BookingsController < ApplicationController
     booking = Booking.find(params[:id])
     availability = booking.availability
 
-    if @booking.status == 'pending'
+    if @booking.status == "pending"
       if @booking.update(booking_params)
         BookingMailer.booking_modified_notification(@booking.speaker, @booking).deliver_now
         render json: @booking
@@ -35,7 +35,7 @@ class Api::V1::BookingsController < ApplicationController
         render json: @booking.errors, status: :unprocessable_entity
       end
     else
-      render json: { error: 'Booking cannot be modified once it is accepted or declined.'}, status: :unprocessable_entity
+      render json: { error: "Booking cannot be modified once it is accepted or declined." }, status: :unprocessable_entity
     end
   end
 

--- a/app/mailers/booking_mailer.rb
+++ b/app/mailers/booking_mailer.rb
@@ -14,4 +14,11 @@ class BookingMailer < ApplicationMailer
     @order = @booking.order
     mail(to: @speaker.email, subject: "New Booking Request")
   end
+
+  def booking_modified_notification(speaker, booking)
+    @speaker = speaker
+    @booking = booking
+    @location = @booking.user.organization.address
+    mail(to: @speaker.email, subject: "Booking Request Modified") 
+  end
 end

--- a/app/mailers/booking_mailer.rb
+++ b/app/mailers/booking_mailer.rb
@@ -19,6 +19,6 @@ class BookingMailer < ApplicationMailer
     @speaker = speaker
     @booking = booking
     @location = @booking.user.organization.address
-    mail(to: @speaker.email, subject: "Booking Request Modified") 
+    mail(to: @speaker.email, subject: "Booking Request Modified")
   end
 end

--- a/app/views/booking_mailer/booking_modified_notification.html.erb
+++ b/app/views/booking_mailer/booking_modified_notification.html.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <style>
+      /* Email styles need to be inline */
+    </style>
+  </head>
+  <body>
+    Booking Request Modified
+  </body>
+</html>

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :organization do
     name { Faker::Educator.secondary_school }
     org_type { :school }
+    association :address, factory: :address
   end
 end

--- a/spec/mailers/booking_mailer_spec.rb
+++ b/spec/mailers/booking_mailer_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe BookingMailer, type: :mailer do
 
     it "creates booking request confirmation" do
       expect(mail.subject).to eql("Booking Request Confirmation")
-      expect(mail.to).to eql([user.email])
-      expect(mail.from).to eql(["no-reply@example.com"])
+      expect(mail.to).to eql([ user.email ])
+      expect(mail.from).to eql([ "no-reply@example.com" ])
     end
   end
 
@@ -24,8 +24,8 @@ RSpec.describe BookingMailer, type: :mailer do
 
     it "creates new booking notification" do
       expect(mail.subject).to eql("New Booking Request")
-      expect(mail.to).to eql([speaker.email])
-      expect(mail.from).to eql(["no-reply@example.com"])
+      expect(mail.to).to eql([ speaker.email ])
+      expect(mail.from).to eql([ "no-reply@example.com" ])
     end
   end
 
@@ -37,8 +37,8 @@ RSpec.describe BookingMailer, type: :mailer do
 
     it "creates booking request modified notification" do
       expect(mail.subject).to eql("Booking Request Modified")
-      expect(mail.to).to eql([speaker.email])
-      expect(mail.from).to eql(["no-reply@example.com"])
+      expect(mail.to).to eql([ speaker.email ])
+      expect(mail.from).to eql([ "no-reply@example.com" ])
     end
 
     it "renders an empty body" do

--- a/spec/mailers/booking_mailer_spec.rb
+++ b/spec/mailers/booking_mailer_spec.rb
@@ -1,5 +1,48 @@
 require "rails_helper"
 
 RSpec.describe BookingMailer, type: :mailer do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:organization) { create(:organization, address: address) }
+  let(:address) { create(:address, street_address: "123 St") }
+  let(:speaker) { create(:user, :speaker_user) }
+
+  describe "booking_confirmation" do
+    let(:user) { create(:user) }
+    let(:booking) { create(:booking, user: user) }
+    let(:mail) { BookingMailer.booking_confirmation(user, booking) }
+
+    it "creates booking request confirmation" do
+      expect(mail.subject).to eql("Booking Request Confirmation")
+      expect(mail.to).to eql([user.email])
+      expect(mail.from).to eql(["no-reply@example.com"])
+    end
+  end
+
+  describe "new_booking_notification" do
+    let(:speaker) { create(:user, :speaker_user) }
+    let(:booking) { create(:booking) }
+    let(:mail) { BookingMailer.new_booking_notification(speaker, booking) }
+
+    it "creates new booking notification" do
+      expect(mail.subject).to eql("New Booking Request")
+      expect(mail.to).to eql([speaker.email])
+      expect(mail.from).to eql(["no-reply@example.com"])
+    end
+  end
+
+  describe "booking_modified_notification" do
+    let(:user) { create(:user, organization: organization) }
+    let(:speaker) { create(:user, :speaker_user) }
+    let(:booking) { create(:booking, user: user) }
+    let(:mail) { described_class.booking_modified_notification(speaker, booking) }
+
+    it "creates booking request modified notification" do
+      expect(mail.subject).to eql("Booking Request Modified")
+      expect(mail.to).to eql([speaker.email])
+      expect(mail.from).to eql(["no-reply@example.com"])
+    end
+
+    it "renders an empty body" do
+      expect(mail.body.encoded).to include("Booking Request Modified")
+    end
+  end
 end


### PR DESCRIPTION
HER-59 Notify Speaker Of Booking Modification<!-- PR Title format: "<JIRA_TICKET_ID>: <TICKET_TITLE>"-->

## Issue

https://raquelanaroman.atlassian.net/browse/HER-59

Description

As a speaker, I want to be notified when a booking request is modified so that I am aware of any changes to my schedule.

Acceptance Criteria
When a booking request is modified, the speaker should receive an email notification about the changes.

The email should include details of the booking.

Update the BookingsController to send a notification email to the speaker when a booking is modified.<!-- Copy the JIRA Ticket Description! ⬇️ -->

#49 
#36 
#60 <!-- Link any related PRs to this PR -->

## Changes
Implementation
Add a method in the BookingMailer to handle the notification email.
def booking_modified_notification(speaker, booking)
  @speaker = speaker
  @booking = booking
  @location = @booking.user.organization.address
  mail(to: @speaker.email, subject: 'Booking Request Modified')
end

Update the update action in the BookingsController to send the notification email when a booking is modified.
def update
  if @booking.status == 'pending'
    if @booking.update(booking_params)
      BookingMailer.booking_modified_notification(@booking.speaker, @booking).deliver_now
      render json: @booking
    else
      render json: @booking.errors, status: :unprocessable_entity
    end
  else
    render json: { error: 'Booking cannot be modified once it is accepted or declined.'}, status: :unprocessable_entity
  end
end

Ensure that when a booking is modified, the speaker receives an email with the updated booking details.

### Review Checklist

- [v] I have documented my code with code comments.
